### PR TITLE
added version prefix string; 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -36,6 +36,10 @@ func Setup(ctx context.Context, cfg *config.Config, r chi.Router, e EmailSender)
 // and then mounts it to the existing router, in order to prevent existing endpoints (i.e. /health) to go through auth.
 func (api *API) mountEndpoints(ctx context.Context) {
 	r := chi.NewRouter()
+	r.Route(api.Cfg.VersionPrefix, func(r chi.Router) {
+		r.Post("/feedback", api.PostFeedback)
+	})
+
 	r.Post("/feedback", api.PostFeedback)
 	api.Router.Mount("/", r)
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -19,12 +19,13 @@ func TestSetup(t *testing.T) {
 		r := chi.NewRouter()
 		ctx := context.Background()
 		cfg := &config.Config{
-			OnsDomain: "localhost",
+			OnsDomain:     "localhost",
+			VersionPrefix: "/v1",
 		}
 		a := api.Setup(ctx, cfg, r, nil)
 
 		Convey("When created the following routes should have been added", func() {
-			So(hasRoute(a.Router, "/feedback", http.MethodPost), ShouldBeTrue)
+			So(hasRoute(a.Router, cfg.VersionPrefix+"/feedback", http.MethodPost), ShouldBeTrue)
 		})
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	OnsDomain                  string        `envconfig:"ONS_DOMAIN"`
 	FeedbackTo                 string        `envconfig:"FEEDBACK_TO"`
 	FeedbackFrom               string        `envconfig:"FEEDBACK_FROM"`
+	VersionPrefix              string        `envconfig:"VERSION_PREFIX"`
 	Mail                       *Mail
 	Sanitize                   *Sanitize
 }
@@ -49,6 +50,7 @@ func Get() (*Config, error) {
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		OnsDomain:                  "localhost",
+		VersionPrefix:              "/v1",
 		Mail: &Mail{
 			Host:     "localhost",
 			Port:     "1025",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ func TestConfig(t *testing.T) {
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,
 					OnsDomain:                  "localhost",
+					VersionPrefix:              "/v1",
 					Mail: &Mail{
 						Host:     "localhost",
 						Port:     "1025",


### PR DESCRIPTION
### What

it's not possible to call this api via the router without this

### How to review

`curl -X POST localhost:23200/v1/feedback --data '{"is_page_useful":true,"is_general_feedback" : true}' -i`

Requires dp-compose web stack & you need to set the config, substituting the IP for your own.

```
		FeedbackAPIURL:                       "http://192.168.1.95:28600", 
		EnableFeedbackAPI:                    true,
```

You also need to make the feedback API listen on 0.0.0.0, otherwise the docker router won't locate it.

### Who can review

Anyone, simple change.

