### PR TITLE
fix/remove extra v1 prefix

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -16,7 +16,7 @@ import (
 // package level constants
 const (
 	Service          = "dp-feedback-api"
-	FeedbackEndpoint = "%s/v1/feedback"
+	FeedbackEndpoint = "%s/feedback"
 	Authorization    = "Authorization"
 	BearerPrefix     = "Bearer "
 )

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -150,7 +150,7 @@ func TestPostFeedback(t *testing.T) {
 
 			Convey("Then the expected request is sent with the expected path, method and auth header", func() {
 				So(httpClientMock.DoCalls(), ShouldHaveLength, 1)
-				So(httpClientMock.DoCalls()[0].Req.URL.String(), ShouldEqual, "http://localhost:1234/v1/feedback")
+				So(httpClientMock.DoCalls()[0].Req.URL.String(), ShouldEqual, "http://localhost:1234/feedback")
 				So(httpClientMock.DoCalls()[0].Req.Method, ShouldEqual, http.MethodPost)
 				So(httpClientMock.DoCalls()[0].Req.Header.Get(sdk.Authorization), ShouldEqual, "Bearer serviceToken")
 			})


### PR DESCRIPTION
### What

Removed extra `v1` prefix that was causing an [error](https://kibana.dp.aws.onsdigital.uk/_plugin/kibana/app/discover#/doc/43f9bc00-9e38-11ec-8c80-b5cdb3f0f750/applogs-2024-12-18?id=1300689487) 
```
"message": "error sending request: Post \"http://localhost:23200/v1/v1/feedback\": dial tcp 127.0.0.1:23200: connect: connection refused"
}
```

### How to review

Sense check
_Optionally_
- Run this branch of the app 
- Add some mail settings
- Run the `dp-frontend-feedback-controller` and add this to `go.mod` `replace github.com/ONSdigital/dp-feedback-api => /path/to/src/ONSdigital/dp-feedback-api`
- Run `dp-design-system` is you like the look and appearance to work!
- Go to http://localhost:25200/feedback and see if the post works

### Who can review

!me
